### PR TITLE
Friendlier to invalid arithmetic expressions

### DIFF
--- a/accelergy/arch_dict_2_obj.py
+++ b/accelergy/arch_dict_2_obj.py
@@ -18,10 +18,10 @@ def fully_define_arch_dict(arch_dict, cc_classes, pc_classes):
                 if attr_val in cinfo['attributes']:
                     cinfo['attributes'][attr_name] = cinfo['attributes'][attr_val]
                 v = parse_expression_for_arithmetic(attr_val, cinfo['attributes'])
-                if not isinstance(v, str): 
-                    cinfo['attributes'][attr_name] = v
-                else:
-                    print(f'ERROR: {attr_val} is not a valid expression. Not setting "{attr_name}" attribute in {cinfo["attributes"]}')
+                if isinstance(v, str):
+                    arithmetic_failed_evaluate_warn(attr_val, attr_name, cname, cinfo['attributes'])
+                cinfo['attributes'][attr_name] = v
+
     return arch_dict
 
 class Architecture(object):

--- a/accelergy/compound_component.py
+++ b/accelergy/compound_component.py
@@ -1,325 +1,485 @@
-# Copyright (c) 2019 Yannan Wu
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+from yaml import load
 from copy import deepcopy
 from accelergy.parsing_utils import *
-class CompoundComponent:
-    def __init__(self, def_info):
-        arch_component = def_info['component']
-        pc_classes = def_info['pc_classes']
-        cc_classes = def_info['cc_classes']
+from collections import OrderedDict
 
-        self.name = arch_component.get_name()
-        self.class_name = arch_component.get_class_name()
-        self.attributes = arch_component.get_attributes()
-        self._primitive_type = cc_classes[self.class_name].get_primitive_type()
-        self._subcomponents = {}
-        self.all_possible_subcomponents = {}
-        self.subcomponent_base_name_map = {}
-        self._actions = []
-        self.set_subcomponents(cc_classes, pc_classes)
-        self.flatten_action_list(cc_classes)
 
-    def get_class_name(self):
-        return self.class_name
+class RawInputs2Dicts():
+    def __init__(self, input_info):
+        self.parser_version = input_info['parser_version']
+        self.possible_top_keys = {'architecture', 'compound_components', 'action_counts', 'ERT',
+                                  'flattened_architecture', 'variables'}
+        self.path_arglist = input_info['path_arglist']
+        self.flatten_arch_spec_dict = {}
+        self.hier_arch_spec_dict = {}
+        self.cc_classes_dict = {}
+        self.pc_classes_dict = {}
+        self.ERT_dict = {}
+        self.action_counts_dict = {}
+        self.config = None
+        self.arch_variables = {}
+        self.load_and_construct_dicts()
 
-    def get_name(self):
-        return self.name
 
-    def get_attributes(self):
-        return self.attributes
-
-    def get_actions(self):
-        return self._actions
-
-    def get_subcomponents(self):
-        return self._subcomponents
-
-    def get_primitive_type(self):
-        return self._primitive_type
-
-    def set_subcomponents(self, cc_classes, pc_classes):
-        self.all_possible_subcomponents[self.name] = self
-        list_of_defined_primitive_components = self.process_subcomponents(self, cc_classes, pc_classes)
-        for primitive_comp in list_of_defined_primitive_components:
-            self._subcomponents[primitive_comp.get_name()] = primitive_comp
-        self.construct_name_base_name_map()
-
-    def process_subcomponents(self, component, cc_classes, pc_classes):
-        """ generate a list of primitive subcomponents of a compound component"""
-
-        list_of_primitive_components = []
-        component_class = cc_classes[component.get_class_name()]
-        compound_attributes = component.get_attributes()
-        subcomponents = deepcopy(component_class.get_subcomponents_as_dict())
-        for default_sub_name, subcomponent in subcomponents.items():
-            defined_sub_name = CompoundComponent.define_subcomponent_name(default_sub_name, compound_attributes)
-            subcomponent.set_name(defined_sub_name)
-        # process the subcomponent attribute values, subcomponent attributes can be:
-        #     1. numbers
-        #     2. string bindings to/arithmetic operations of compound component attributes
-        # default sub-component-component attribute values that are not specified in the top-level, default values can be :
-        #     1. numbers
-        #     2. bindings/arithmetic operations of other sub-compound-component attribute values
-        for subname, subcomponent in subcomponents.items():
-            # create nested name for subcomponents
-            subname = component.get_name() + '.' + subcomponent.get_name() if component is not self \
-                                                                           else subcomponent.get_name()
-            subcomponent.set_name(subname)
-            subclass_name = subcomponent.get_class_name()
-            sub_class_type = 'compound' if subclass_name in cc_classes else 'primitive'
-            if sub_class_type == 'compound':
-                subclass_def = cc_classes[subclass_name]
-                defined_subcomponent = CompoundComponent.define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass_def)
-                list_of_new_defined_primitive_components = self.process_subcomponents(defined_subcomponent, cc_classes, pc_classes)
-                for new_defined_pc in list_of_new_defined_primitive_components:
-                    list_of_primitive_components.append(new_defined_pc)
+    def check_input_parser_version(self, input_parser_version, input_file_type, input_file_path):
+        # Accelergy v0.3 can parser input files of version 0.2 and 0.3 (except ERT)
+        if input_file_type is not 'ERT':
+            if input_file_type == 'config':
+                ASSERT_MSG(input_parser_version == 0.2 or input_parser_version == 0.3,
+                           'config file version outdated. Latest version is v.%s \
+                            \n Please delete the original file, and run accelergy to create a new default config file.\
+                            \n Please ADD YOUR USER_DEFINED file paths BACK to the updated config file at \
+                            ~/.config/accelergy/accelergy_config.yaml' % self.parser_version)
             else:
-                subclass_def = pc_classes[subclass_name]
-                defined_subcomponent = CompoundComponent.define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass_def)
-                list_of_primitive_components.append(defined_subcomponent)
-            self.all_possible_subcomponents[subname] = defined_subcomponent
+                ASSERT_MSG(input_parser_version == 0.2 or input_parser_version == 0.3,
+                           'input parser version for %s is v%s, cannot be parsed by current accelergy v%s'
+                           % (input_file_path, input_parser_version, self.parser_version))
 
-        return list_of_primitive_components
+            # if input_parser_version < self.parser_version:
+            #     WARN('Your %s input file has an older version. The most up-to-date version is %s '
+            #          '--> Only the value of the "version" key needs to be updated '
+            #          '(the syntax of the content does not need to be updated) '
+            #          '\n --- OK'
+            #          %(input_file_path, self.parser_version))
+        else:
+            ASSERT_MSG(input_parser_version == 0.3,
+                       'ERT input file is version v%s, cannot be parsed by Accelergy v%s. '
+                       '\n---> Please use Accelergy v0.2/ update your ERT input file format/ '
+                       'regenerate the ERT using your design description'
+                       % (input_parser_version, self.parser_version))
 
+    def load_and_construct_dicts(self):
+        # load and classify input files
 
-    def flatten_action_list(self, cc_classes):
-        top_level_action_list = self.flatten_top_level_action_list(cc_classes[self.get_class_name()])
-        for action_idx in range(len(top_level_action_list)):
-            primitive_list = self.flatten_action_list_for_an_action(self.get_name(),
-                                                                    top_level_action_list[action_idx],
-                                                                    cc_classes)
-            top_level_action_list[action_idx].set_primitive_list(primitive_list)
-        self._actions = top_level_action_list
-
-
-    def flatten_action_list_for_an_action(self, component_name, action, cc_classes):
-        list_of_primitive_actions = []
-        # 1. expand the list of subcomponents in the action (subcomponent name can be in list format)
-        # 2. rename each subcomponent with hierarchical name
-        # 3. define the range of the arguments of each subcomponent action
-        # 4. if the action is a compound action -> go to 1
-        #    if the action is a primitive action -> throw it in the list
-        action_copy = deepcopy(action)
-        subcomponent_actions = action_copy.get_subcomps() # subcomponent_name: list of action objects
-        compound_attributes = self.find_subcomponent_obj(component_name).get_attributes()
-        compound_arguments = action.get_arguments()
-        aggregated_mappings = deepcopy(compound_attributes) if compound_arguments is None \
-                              else merge_dicts(compound_attributes, compound_arguments)
-
-        for subcomp_name, action_obj_list in subcomponent_actions.items():
-            # make sure the top-level component name is not added as prefix
-            if not component_name == self.get_name():
-                defined_subcomp_name = component_name + '.' + CompoundComponent.define_subcomponent_name(subcomp_name, aggregated_mappings)
+        # construct new or parse existing config file
+        self.construct_parse_config_file()
+        
+        # merge all paths (input + compound compondnt lib)
+        all_paths = self.path_arglist
+        for cc_lib_path in self.config["compound_components"]:
+            all_paths.append(cc_lib_path)
+        
+        # go through each path in the merged list
+        input_file_info = {}
+        for path in all_paths:
+            if os.path.isfile(path) and path.split('.')[-1] == "yaml":
+                loaded_content_list = self.load_file(path)
+                for loaded_content in loaded_content_list:
+                    if loaded_content['top_key'] not in input_file_info:
+                        input_file_info[loaded_content['top_key']] = []
+                    input_file_info[loaded_content['top_key']].append(loaded_content)
+            elif os.path.isdir(path):
+                for root, directories, file_names in os.walk(path):
+                    for file_name in file_names:
+                        if file_name.split('.')[-1] == "yaml":
+                            file_path = os.path.join(root, file_name)
+                            loaded_content_list = self.load_file(file_path)
+                            for loaded_content in loaded_content_list:
+                                if loaded_content['top_key'] not in input_file_info:
+                                    input_file_info[loaded_content['top_key']] = []
+                                input_file_info[loaded_content['top_key']].append(loaded_content)
             else:
-                defined_subcomp_name = CompoundComponent.define_subcomponent_name(subcomp_name, aggregated_mappings)
+                ERROR_CLEAN_EXIT('Cannot recognize input path: ', path)
 
-            subclass_name = self.find_subcomponent_obj(defined_subcomp_name).get_class_name()
-            subcomponent_class_type = 'compound' if subclass_name in cc_classes else 'primitive'
-            defined_action_obj_list = CompoundComponent.define_subactions(action_obj_list, aggregated_mappings)
-            for subaction in defined_action_obj_list:
-                if subcomponent_class_type == 'primitive':
-                    list_of_primitive_actions.append((defined_subcomp_name, subaction))
+        if 'variables' in input_file_info:
+            for variable_spec in input_file_info['variables']:
+                for var_name, var_var in variable_spec['content']['variables'].items():
+                    if type(var_var) is str:
+                        if var_var in variable_spec['content']['variables']:
+                            variable_spec['content']['variables'][var_name] = variable_spec['content']['variables'][var_var]
+                        else:
+                            v = parse_expression_for_arithmetic(var_var, variable_spec['content']['variables'])
+                            if isinstance(v, str):
+                                arithmetic_failed_evaluate_warn(var_var, var_name, 'variables', variable_spec['content']['variables'])
+                            variable_spec['content']['variables'][var_name] = v
+
+                self.arch_variables.update(variable_spec['content']['variables'])
+
+        for top_key, top_key_file_list in input_file_info.items():
+            if top_key != 'variables':
+                for file_info in top_key_file_list:
+                    YAML_parser_fname = top_key + '_input_parser'
+                    file_path = file_info['path']
+                    INFO('Parsing file %s for %s info' % (file_path, top_key))
+                    getattr(self, YAML_parser_fname)(file_info)
+
+
+        # construct primitive classes dictionary
+        self.primitive_classes_input_parser()
+
+    def load_file(self, file_path):
+        if '.yaml' in file_path:
+            file_obj = open(file_path)
+            file = load(file_obj, accelergy_loader)
+            loaded_content_list =[]
+            for top_key in file.keys():
+                if top_key not in self.possible_top_keys:
+                    WARN('Cannot recognize the top key "%s" in file %s' % (top_key, file_path))
                 else:
-                    default_subcomp_actions = deepcopy(cc_classes[subclass_name].get_action(subaction.get_name()).get_subcomps())
-                    subaction.set_subcomps(default_subcomp_actions)
-                    new_list_of_primitive_actions = self.flatten_action_list_for_an_action(defined_subcomp_name, subaction, cc_classes)
-                    for new_primitive_action in new_list_of_primitive_actions:
-                        list_of_primitive_actions.append(new_primitive_action)
-        return list_of_primitive_actions
+                    # YAML_parser_fname = top_key + '_input_parser'
+                    loaded_content_list.append({'top_key': top_key, 'content': file, 'path': file_path})
+                    # getattr(self, YAML_parser_fname)(file_info)
+            file_obj.close()
+            return loaded_content_list
 
-    @staticmethod
-    def define_subactions(subactions, aggregated_dict):
-        defined_subactions = []
-        for subaction in subactions:
-            parsed_action_share = CompoundComponent.parse_action_share(subaction, aggregated_dict)
-            subaction.set_action_share(parsed_action_share)
-            if subaction.get_arguments() is not None:
-                for subarg_name, subarg_val in subaction.get_arguments().items():
-                    if type(subarg_val) is str:
-                        try:
-                            subaction.set_argument({subarg_name: aggregated_dict[subarg_val]})
-                        except KeyError:
-                            v = parse_expression_for_arithmetic(subarg_val, aggregated_dict)
-                            if not isinstance(v, str):
-                                subaction.set_argument({subarg_name: v})
+    def architecture_input_parser(self, file_info):
+        """responsible for parsing the loaded architecture YAML file """
+
+        top_key = 'architecture'
+        content = file_info['content']
+        file_path = file_info['path']
+
+        # only one arch file is allowed
+        ASSERT_MSG(self.hier_arch_spec_dict == {},
+                   'Second architecture description detected at %s ... '
+                   'Only one architecture is allowed...' % (file_path))
+
+        # check top-level syntax of input file
+        ASSERT_MSG('version' in content[top_key], '%s must contain "version" key' % (file_path))
+        self.check_input_parser_version(content[top_key]['version'], 'architecture', file_path)
+
+        if 'subtree' in content[top_key]:
+            ASSERT_MSG(type(content[top_key]['subtree']) is list,
+                       'File content not legal: %s, subtree key must have value of type list' % (file_path))
+        elif 'local' in content[top_key]:
+            ASSERT_MSG(type(content[top_key]['local']) is list,
+                       'File content not legal: %s, local key must have value of type list' % (file_path))
+        else:
+            ERROR_CLEAN_EXIT('Architecture Description must contain subtree or local key at top-level')
+
+        # create arch spec dict
+        self.hier_arch_spec_dict = {'architecture': {}}
+        self.flatten_arch_spec_dict = {'version': self.parser_version, 'components': {}}
+        arch_comp_list = content[top_key]
+        if 'subtree' in arch_comp_list:
+            arch_name = arch_comp_list['subtree'][0]['name']
+            global_attributes = {} if 'attributes' not in arch_comp_list['subtree'][0] \
+                else arch_comp_list['subtree'][0]['attributes']
+            if 'attributes' in arch_comp_list['subtree']:
+                ASSERT_MSG(type(arch_comp_list['subtree'['attributes']]) is dict,
+                           'attributes must be specified in dictionary format')
+            arch_comp_list['subtree'][0] = self.tree_node_classification(OrderedDict(arch_comp_list['subtree'][0]), arch_name, global_attributes)
+        else:
+            arch_comp_list = self.tree_node_classification(arch_comp_list, None, {})
+        self.hier_arch_spec_dict['architecture'] = OrderedDict(arch_comp_list)
+
+    def tree_node_classification(self, node_description, prefix, node_attrs):
+        """
+        Classify the nodes in a level to recursively parse (subtree) or construct components (local) for the architecture
+        :param node_description: a dictionary that describes the subtree and local nodes in this level
+        :param prefix: the prefix that needs to be preappend to all of the node names in this level
+        :param node_attrs: a dictionary that contains the explicitly specified attributes and the projected upper level shared attributes
+        :return: None
+        """
+        # interpret the mapping and arithmetic operations in the raw description
+        all_attrs = deepcopy(node_attrs)
+        all_attrs.update(self.arch_variables)
+        for attr_name, attr_val in node_attrs.items():
+            if type(attr_val) is str:
+                if attr_val in all_attrs:
+                    node_attrs[attr_name] = all_attrs[attr_val]
+                    all_attrs[attr_name] = all_attrs[attr_val]
+                else:
+                    v = parse_expression_for_arithmetic(attr_val, all_attrs)
+                    if isinstance(v, str):
+                        arithmetic_failed_evaluate_warn(attr_val, attr_name, prefix, node_attrs)
+                    node_attrs[attr_name] = v
+                    all_attrs[attr_name] = node_attrs[attr_name]
+
+        if 'subtree' in node_description:
+            ASSERT_MSG(isinstance(node_description['subtree'], list), " %s.subtree has to be a list"%(prefix))
+            node_description['subtree'] = self.parse_architecture_subtree(node_description['subtree'], prefix, node_attrs)
+
+        if 'local' in node_description:
+            ASSERT_MSG(isinstance(node_description['local'], list),
+                       "error: %s.local has to be a list of components"%prefix)
+            for c_id in range(len(node_description['local'])):
+                node_info = node_description['local'][c_id]
+                ASSERT_MSG('name' in node_info, 'name must be specified for each node')
+                if 'attributes' not in node_info:
+                    node_info['attributes'] = {}
+                else:
+                    ASSERT_MSG(type(node_info['attributes']) is dict,
+                    '%s: attributes must be specified in dictionary format'%(node_info['name']))
+                for attr_name, attr_val in node_attrs.items():
+                    if attr_name not in node_info['attributes']:
+                        node_info['attributes'][attr_name] = attr_val
+
+                all_attrs = deepcopy(node_info['attributes'])
+                all_attrs.update(self.arch_variables)
+                for attr_name, attr_val in node_info['attributes'].items():
+                    if type(attr_val) is str:
+                        if attr_val in all_attrs:
+                            node_info['attributes'][attr_name] = all_attrs[attr_val]
+                            all_attrs[attr_name] = all_attrs[attr_val]
+                        else:
+                            v = parse_expression_for_arithmetic(attr_val, all_attrs)
+                            if isinstance(v, str):
+                                arithmetic_failed_evaluate_warn(attr_val, attr_name, 'variables', node_info)
+                            node_info['attributes'][attr_name] = v
+                            all_attrs[attr_name] = node_info['attributes'][attr_name]
+
+
+                name_base, list_suffix, list_length = interpret_component_list(node_info['name'], all_attrs)
+                if list_suffix is not None:
+                    node_info['name'] = name_base + list_suffix
+
+                node_description['local'][c_id] = OrderedDict(node_info)
+
+                # generate the flattened version of the architecture
+                local_node_name = prefix + '.' + node_info['name'] if prefix is not None else node_info['name']
+                node_info['name'] = local_node_name
+                self.flatten_arch_spec_dict['components'][local_node_name] = node_info
+
+        if 'subtree' not in node_description and 'local' not in node_description:
+            ERROR_CLEAN_EXIT('Unrecognized tree node type', node_description)
+
+        return node_description
+
+    def parse_architecture_subtree(self, subtree_description, prefix, shared_attributes_dict=None):
+        ASSERT_MSG(isinstance(subtree_description, list), '%s.subtree needs to be a list'%prefix)
+
+        for subtree_idx in range(len(subtree_description)):
+            subtree_item_description = subtree_description[subtree_idx]
+            if 'name' not in subtree_item_description:
+                ERROR_CLEAN_EXIT('error: architecture description...',
+                                 ' "name" needs to be specified as a key in node description', subtree_item_description)
+
+            if shared_attributes_dict is None and 'attributes' not in subtree_item_description:
+                node_attrs = None
+            elif shared_attributes_dict is not None and 'attributes' not in subtree_item_description:
+                node_attrs = deepcopy(shared_attributes_dict)
+            elif shared_attributes_dict is None and 'attributes' in subtree_item_description:
+                node_attrs = subtree_item_description['attributes']
+            else:  # shared_attributes_dict is not None and attributes in node_description
+                node_attrs = deepcopy(shared_attributes_dict)
+                node_attrs.update(subtree_item_description['attributes'])
+
+            all_attrs = deepcopy(node_attrs)
+            all_attrs.update(self.arch_variables)
+            node_name = subtree_item_description['name']
+            name_base, list_suffix, list_length = interpret_component_list(node_name, all_attrs)
+            if list_suffix is not None:
+                node_name = name_base + list_suffix
+            subtree_item_description['name'] = node_name
+            item_prefix = prefix + '.' + node_name  # generated for the flattened arch
+            subtree_description[subtree_idx] = OrderedDict(self.tree_node_classification(subtree_item_description, item_prefix, node_attrs))
+        return subtree_description  # accumulated hierarchical info for the hierarchical arch
+
+    def compound_components_input_parser(self, file_info):
+        """responsible for parsing the loaded compound component description YAML files """
+
+        top_key = 'compound_components'
+
+        file_path = file_info['path']
+        file_reload = load(open(file_path), accelergy_loader_ordered)
+        content = file_reload
+
+        # check top level syntax, check parser version
+        ASSERT_MSG('version' and 'classes' in content[top_key],
+                   'File content not legal: %s, %s must contain '
+                   '"version" and "classes" keys' % (file_path, top_key))
+        self.check_input_parser_version(content[top_key]['version'], 'compound_component', file_path)
+        ASSERT_MSG(type(content[top_key]['classes']) is list,
+                   'File content not legal: %s, "classes" key must have value of type list' % file_path)
+
+        # check syntax of each specified cc class and add into the cc_class_dict
+        cc_classes_list = content[top_key]['classes']
+        for cc_class in cc_classes_list:
+            ASSERT_MSG('name' in cc_class.keys() and 'attributes' in cc_class.keys()
+                       and 'actions' in cc_class.keys() and 'subcomponents' in cc_class.keys(),
+                       'missing required keys in compound component class description: \n %s' % cc_class)
+            if cc_class['name'] in self.cc_classes_dict:
+                WARN('Redefined compound component class %s in file %s' % (cc_class['name'], file_path))
+            for subcomponent_info in cc_class['subcomponents']:
+                ASSERT_MSG('name' in subcomponent_info.keys() and 'class' in subcomponent_info.keys(),
+                           '"name" and "class" keys must be specified for the subcomponents of the '
+                           'compound component class: %s' % (cc_class['name']))
+                if 'area_share' not in subcomponent_info:
+                    subcomponent_info['area_share'] = 1  # default area share is 1
+            for action_info in cc_class['actions']:
+                ASSERT_MSG('name' in action_info.keys() and 'subcomponents' in action_info.keys(),
+                           '"name" and "subcomponents" keys must be specified for compound action %s' % (
+                           action_info['name']))
+                for subcomponent_actions in action_info['subcomponents']:
+                    ASSERT_MSG('actions' in subcomponent_actions and 'name' in subcomponent_actions,
+                               '"name" and "actions" keys of the subcomponent must be specified for compound action'
+                               ' %s' % (action_info['name']))
+                    for subcomponent_action in subcomponent_actions['actions']:
+                        ASSERT_MSG('name' in subcomponent_action,
+                                   '"name" key of the subcomponent action needs to be specified for '
+                                   'compound action: %s, subcomponent: %s' % (
+                                   action_info['name'], subcomponent_actions['name']))
+                        if 'action_share' not in subcomponent_action:
+                            if 'repeat' in subcomponent_action:
+                                subcomponent_action['action_share'] = subcomponent_action['repeat']
                             else:
-                                print('available compound arguments and attributes: ', aggregated_dict)
-                                print('primitive argument to for binding:', subarg_val)
-                                ERROR_CLEAN_EXIT('subcomponent argument name cannot be ',
-                                                 'mapped to upper class arguments', subarg_val)
-            defined_subactions.append(subaction)
-        return defined_subactions
+                                subcomponent_action['action_share'] = 1  # default action share is 1
+            self.cc_classes_dict[cc_class['name']] = deepcopy(cc_class)
 
-    @staticmethod
-    def parse_action_share(action, upper_level_binding):
-        """
-        evaluates the values of action_share of a sub-component action
-        - default value of action_share is 1
-        - string bindings are allowed, and bindings can be from:
-            1. compound attributes
-            2. compound action arguments (its own upper-level action)
-        - arithemtic operations are allowed in specifying action_share value
+    def construct_parse_config_file(self):
+        """load exisiting config file content (if any)/ create a default config file"""
 
-        """
-        action_share = action.get_action_share()
-        if action_share is not None:
-            if type(action_share) is not int:
-                v = parse_expression_for_arithmetic(action_share, upper_level_binding)
-                if not isinstance(v, str):
-                    parsed_action_share = v
+        possible_config_dirs = ['.' + os.sep, os.path.expanduser('~') + '/.config/accelergy/']
+        config_file_name = 'accelergy_config.yaml'
+        for possible_dir in possible_config_dirs:
+            if os.path.exists(possible_dir + config_file_name):
+                original_config_file_path = possible_dir + config_file_name
+                original_content_obj = open(original_config_file_path)
+                original_content = load(original_content_obj, accelergy_loader)
+                original_content_obj.close()
+                INFO('config file located:', original_config_file_path)
+                print('config file content: \n', original_content)
+                if 'version' not in original_content:
+                    ERROR_CLEAN_EXIT('config file has no version number, cannot proceed')
+                file_version = original_content['version']
+                self.check_input_parser_version(file_version, 'config', original_config_file_path)
+                self.config = original_content
+                return
+
+        create_folder(possible_config_dirs[1])
+        config_file_path = possible_config_dirs[1] + config_file_name
+        curr_file_path = os.path.abspath(__file__)
+        accelergy_share_folder_path = os.path.abspath(curr_file_path + '../../../../../../share/accelergy/')
+        default_estimator_path = os.path.abspath(accelergy_share_folder_path + '/estimation_plug_ins/')
+        default_pc_lib_path = os.path.abspath(accelergy_share_folder_path + '/primitive_component_libs/')
+        
+        config_file_content = {'version': self.parser_version,
+                               'estimator_plug_ins': [default_estimator_path],
+                               'primitive_components': [default_pc_lib_path],
+                               'compound_components': []}  # by default, CCs are always input files
+
+        INFO('Accelergy creating default config at:', possible_config_dirs[1] + config_file_name, 'with:\n',
+             config_file_content)
+        write_yaml_file(config_file_path, config_file_content)
+        self.config = config_file_content
+
+    def primitive_classes_input_parser(self):
+        """construct a dictionary for primitive classes"""
+        primitive_class_paths = self.config['primitive_components']
+        for pc_path in primitive_class_paths:
+            if '.yaml' in pc_path:
+                self.expand_primitive_component_lib_info(pc_path)
+            for root, directories, file_names in os.walk(pc_path):
+                for file_name in file_names:
+                    if '.lib.yaml' in file_name:
+                        pc_path = root + os.sep + file_name
+                        self.expand_primitive_component_lib_info(pc_path)
+
+        ASSERT_MSG(not len(self.pc_classes_dict) == 0, 'No primitive component class found, '
+                                                       'please check if the paths in config file are correct')
+
+
+    def expand_primitive_component_lib_info(self, pc_path):
+        primitive_component_list_obj = open(pc_path)
+        primitive_component_list = load(primitive_component_list_obj, accelergy_loader)
+        primitive_component_list_obj.close()
+        for idx in range(len(primitive_component_list['classes'])):
+            pc_description = primitive_component_list['classes'][idx]
+            if pc_description['name'] in self.pc_classes_dict:
+                WARN(pc_description['name'], 'redefined in', pc_path)
+            self.pc_classes_dict[pc_description['name']] = deepcopy(pc_description)
+        INFO('primitive component file parsed: ', pc_path)
+
+    def ERT_input_parser(self, file_info):
+        top_key = 'ERT'
+        file_path = file_info['path']
+        content = file_info['content'][top_key]
+        ERT_component_entry_list = content['tables']
+
+        ASSERT_MSG('version' and 'tables' in content, 'ERT input must contain the "version" and "tables" keys')
+        ASSERT_MSG(isinstance(content['tables'], list), 'ERT tables must be in the form of list')
+        self.check_input_parser_version(content['version'], 'ERT', file_path)
+
+        for ERT_component_entry in ERT_component_entry_list:
+            ASSERT_MSG('name' and 'actions' in ERT_component_entry,
+                       '"name" and "actions" keys must be specified in each ERT component entry')
+            component_name = ERT_component_entry['name']
+            action_dict_summary = {}
+            action_list = ERT_component_entry['actions']
+            for action in action_list:
+                if action['name'] not in action_dict_summary: action_dict_summary[action['name']] = []
+                action_dict_summary[action['name']].append(action)
+            self.ERT_dict[component_name] = action_dict_summary
+
+    def action_counts_input_parser(self, file_info):
+        top_key = 'action_counts'
+        file_path = file_info['path']
+        ASSERT_MSG('version' in file_info['content'][top_key],
+                   'Please specify the version of the action counts file: %s' % (file_path))
+        self.check_input_parser_version(file_info['content'][top_key]['version'], 'action counts', file_path)
+        action_counts_dict = file_info['content'][top_key]
+        ASSERT_MSG('subtree' in action_counts_dict or 'local' in action_counts_dict,
+                   'the action counts must contain the "subtree" key or "local" key at the top level: %s' % file_path)
+        self.flatten_action_counts(None, action_counts_dict)
+
+    def flatten_action_counts(self, prefix, node_description):
+        if 'local' in node_description:
+            local_nodes = node_description['local']
+            ASSERT_MSG(isinstance(local_nodes, list), 'local nodes are not specified in list format in action counts')
+            for local_node in local_nodes:
+                ASSERT_MSG("name" and 'action_counts' in local_node, '"name" and "action_counts" need to be '
+                                                                     'specified as a keys in action count local node descriptions: %s' % local_node)
+                if prefix is None:
+                    full_name = local_node['name']
                 else:
-                    if action_share in upper_level_binding:
-                       parsed_action_share = upper_level_binding[action_share]
-                    else:
-                        parsed_action_share = None
-                        ERROR_CLEAN_EXIT('action_share/repeat value for primitive action cannot be parsed, ',
-                                      'no binding found in compound arguments/ attributes',action,
-                                         'available binding:', upper_level_binding)
-                return parsed_action_share
-            # return the actual value if action_share is an integer
-            return action_share
-        # default action_share value is 1
-        return 1
+                    full_name = prefix + '.' + local_node['name']
+                self.action_counts_dict[full_name] = local_node['action_counts']
 
-    def flatten_top_level_action_list(self, component_class):
-        actionNameList = component_class.get_action_name_list()
-        flattenedActionList = []
-        for actionName in actionNameList:
-            actionObj = deepcopy(component_class.get_action(actionName))
-            flattened = actionObj.flatten_action_args_into_list(self.attributes)
-            for action in flattened:
-                flattenedActionList.append(action)
-        return flattenedActionList
-
-    @staticmethod
-    def define_subcomponent_name(subcomponent_name, mapping_dictionary):
-        # define the list index specified in the subcomponents (if any)
-        # mapping dictionary contains key-value paris where the keys can be used as reference in the list definition
-
-        name_base, list_suffix, list_length = interpret_component_list(subcomponent_name, mapping_dictionary)
-        if list_suffix is not None: subcomponent_name = name_base + list_suffix
-        return subcomponent_name
-
-
-    @staticmethod
-    def define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass):
-        for attr_name, attr_val in subcomponent.get_attributes().items():
-            if type(attr_val) is str:
-                if attr_val in compound_attributes:
-                    subcomponent.add_new_attr({attr_name: compound_attributes[attr_val]})
+        if 'subtree' in node_description:
+            subtree_nodes = node_description['subtree']
+            ASSERT_MSG(isinstance(subtree_nodes, list),
+                       'subtree nodes are not specified in list format in action counts')
+            for subtree_node_description in subtree_nodes:
+                ASSERT_MSG("name" in subtree_node_description, ' "name" need to be specified in the subtree node: %s'
+                           % subtree_node_description)
+                if prefix is None:
+                    subtree_prefix = subtree_node_description['name']
                 else:
-                    v = parse_expression_for_arithmetic(attr_val, compound_attributes)
-                    if not isinstance(v, str):
-                        subcomponent.add_new_attr({attr_name: v})
-                    else:
-                        print(f'ERROR: {attr_val} is not a valid expression. Not setting "{attr_name}" attribute in {subcomponent.get_attributes()}')
-                        
-        attrs_to_be_applied = subclass.get_default_attr_to_apply(subcomponent.get_attributes())
-        subcomponent.add_new_attr(attrs_to_be_applied)
-        CompoundComponent.apply_internal_bindings(subcomponent)
-        if type(subcomponent.get_area_share()) is str:
-            combined_attributes = merge_dicts(compound_attributes, subcomponent.get_attributes())
-            v = parse_expression_for_arithmetic(subcomponent.get_area_share(), combined_attributes)
-            if not isinstance(v, str):
-                subcomponent.set_area_share(v)
-            else:
-                ASSERT_MSG(subcomponent.get_area_share() in combined_attributes,
-                           'Unable to interpret the area share for subcomponent: %s' %(subcomponent.get_name()))
-                subcomponent.set_area_share(combined_attributes[subcomponent.get_area_share()])
-        return subcomponent
+                    subtree_prefix = prefix + '.' + subtree_node_description['name']
+                self.flatten_action_counts(subtree_prefix, subtree_node_description)
 
-    @staticmethod
-    def apply_internal_bindings(component):
-        """ Locate and process any mappings or arithmetic operations between the component attributes"""
+    def get_hier_arch_spec_dict(self):
+        ASSERT_MSG(not self.hier_arch_spec_dict == {}, 'Cannot get hierarchical architecture spec from raw inputs')
+        return self.hier_arch_spec_dict
 
-        for attr_name, attr_val in component.get_attributes().items():
-            if type(attr_val) is str:
-                if attr_val in component.get_attributes():
-                    component.add_new_attr({attr_name: component.get_attributes()[attr_val]})
-                else:
-                    v = parse_expression_for_arithmetic(attr_val, component.get_attributes())
-                    if not isinstance(v, str):
-                        component.add_new_attr({attr_name:v})
-                    else:
-                        print(f'ERROR: {attr_val} is not a valid expression. Not setting "{attr_name}" attribute in {component.get_attributes()}')
+    def get_flatten_arch_spec_dict(self):
+        ASSERT_MSG(not self.flatten_arch_spec_dict == {}, 'Cannot get architecture spec from raw inputs')
+        return self.flatten_arch_spec_dict
 
-    def construct_name_base_name_map(self):
-        self.subcomponent_base_name_map = {}
-        for subname in self.all_possible_subcomponents:
-            sub_base_name = remove_brackets(subname)
-            self.subcomponent_base_name_map[sub_base_name] = subname
+    def get_pc_classses(self):
+        ASSERT_MSG(not self.pc_classes_dict == {}, 'Cannot get primitive component class from raw inputs')
+        return self.pc_classes_dict
 
-    def find_subcomponent_obj(self, subcomponent_name):
-        """ find the corresponding subcomponent def to retrieve the action-related information"""
+    def get_cc_classses(self):
+        if self.cc_classes_dict == {}:
+            WARN('No compound component classes specified, architecture can only contain primitive components')
+        return self.cc_classes_dict
 
-        subcomponent_base_name = remove_brackets(subcomponent_name)
-        ASSERT_MSG(self.subcomponent_base_name_map[subcomponent_base_name] in self.all_possible_subcomponents,
-                   'subcomponent: %s not found'%(self.subcomponent_base_name_map[subcomponent_base_name]))
-        subcomp_obj = self.all_possible_subcomponents[self.subcomponent_base_name_map[subcomponent_base_name]]
-        ASSERT_MSG(comp_name_within_range(subcomponent_name, subcomp_obj.get_name()),
-                   'subcompnent name %s in action definition does not have a valid index (should be a subset of %s)'
-                   %(subcomponent_name, subcomp_obj.get_name()))
-        return subcomp_obj
+    def get_estimation_plug_in_paths(self):
+        ASSERT_MSG(self.config is not None and 'estimator_plug_ins' in self.config,
+                   'config is not properly defined \n %s' % self.config)
+        path_list = self.config['estimator_plug_ins']
+        return path_list
 
+    def get_action_counts_dict(self):
+        if self.action_counts_dict == {}:
+            WARN('No action counts are specified as yaml input')
+        return self.action_counts_dict
 
+    def get_ERT_dict(self):
+        if self.ERT_dict == {}:
+            WARN('No ERT is specified as yaml input')
+        return self.ERT_dict
 
-    # ------------ CONVERSION TO DICTS for BETTER OUTPUTS FUNCTIONS ------------#
-    def get_subcomponents_as_dict(self):
-        subcomp_dict = {}
-        for sub_name, sub_obj in self._subcomponents.items():
-            subcomp_dict[sub_name] = {'class': sub_obj.get_class_name(),
-                                      'attributes': sub_obj.get_attributes(),
-                                      'area_share': sub_obj.get_area_share()}
-        return subcomp_dict
-
-    def get_dict_representation(self):
-        """ Generate the information of the component component in a dictionary format
-            including: (1) attributes (2) class (2) flattened primitive list (2) flattened actions
-        """
-
-        from collections import OrderedDict
-        cc_dict = OrderedDict()
-
-        subcomponent_dict = self.get_subcomponents_as_dict()
-        subcomponent_list = []
-        for subcomp_name, subcomp_info_dict in subcomponent_dict.items():
-            new_info_dict = OrderedDict({'name': subcomp_name})
-            new_info_dict.update(subcomp_info_dict)
-            subcomponent_list.append(new_info_dict)
-
-        cc_dict.update({'name': self.get_name(),
-                        'class': self.get_class_name(),
-                        'attributes': self.get_attributes(),
-                        'primitive_components': subcomponent_list,
-                        'actions': []})
-        idx = 0
-        for action in self._actions:
-            cc_dict['actions'].append(OrderedDict({'name': action.get_name(),
-                                                   'arguments': action.get_arguments(),
-                                                   'primitive_actions': []}))
-            for pc_action_tuple in action.get_primitive_list():
-                cc_dict['actions'][idx]['primitive_actions'].append(
-                    OrderedDict({'name': pc_action_tuple[0],
-                                 'action': pc_action_tuple[1].get_name(),
-                                 'arguments': pc_action_tuple[1].get_arguments(),
-                                 'action_share': pc_action_tuple[1].get_action_share()}))
-            idx = idx + 1
-        return cc_dict
+    def get_available_inputs(self):
+        available_inputs = []
+        if not self.flatten_arch_spec_dict == {}:
+            available_inputs.append('architecture_spec')
+        if not self.cc_classes_dict == {}:
+            available_inputs.append('compound_component_classes')
+        if not self.action_counts_dict == {}:
+            available_inputs.append('action_counts')
+        if not self.ERT_dict == {}:
+            available_inputs.append('ERT')
+        return available_inputs

--- a/accelergy/compound_component.py
+++ b/accelergy/compound_component.py
@@ -1,485 +1,323 @@
-from yaml import load
+# Copyright (c) 2019 Yannan Wu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from copy import deepcopy
 from accelergy.parsing_utils import *
-from collections import OrderedDict
+class CompoundComponent:
+    def __init__(self, def_info):
+        arch_component = def_info['component']
+        pc_classes = def_info['pc_classes']
+        cc_classes = def_info['cc_classes']
 
+        self.name = arch_component.get_name()
+        self.class_name = arch_component.get_class_name()
+        self.attributes = arch_component.get_attributes()
+        self._primitive_type = cc_classes[self.class_name].get_primitive_type()
+        self._subcomponents = {}
+        self.all_possible_subcomponents = {}
+        self.subcomponent_base_name_map = {}
+        self._actions = []
+        self.set_subcomponents(cc_classes, pc_classes)
+        self.flatten_action_list(cc_classes)
 
-class RawInputs2Dicts():
-    def __init__(self, input_info):
-        self.parser_version = input_info['parser_version']
-        self.possible_top_keys = {'architecture', 'compound_components', 'action_counts', 'ERT',
-                                  'flattened_architecture', 'variables'}
-        self.path_arglist = input_info['path_arglist']
-        self.flatten_arch_spec_dict = {}
-        self.hier_arch_spec_dict = {}
-        self.cc_classes_dict = {}
-        self.pc_classes_dict = {}
-        self.ERT_dict = {}
-        self.action_counts_dict = {}
-        self.config = None
-        self.arch_variables = {}
-        self.load_and_construct_dicts()
+    def get_class_name(self):
+        return self.class_name
 
+    def get_name(self):
+        return self.name
 
-    def check_input_parser_version(self, input_parser_version, input_file_type, input_file_path):
-        # Accelergy v0.3 can parser input files of version 0.2 and 0.3 (except ERT)
-        if input_file_type is not 'ERT':
-            if input_file_type == 'config':
-                ASSERT_MSG(input_parser_version == 0.2 or input_parser_version == 0.3,
-                           'config file version outdated. Latest version is v.%s \
-                            \n Please delete the original file, and run accelergy to create a new default config file.\
-                            \n Please ADD YOUR USER_DEFINED file paths BACK to the updated config file at \
-                            ~/.config/accelergy/accelergy_config.yaml' % self.parser_version)
+    def get_attributes(self):
+        return self.attributes
+
+    def get_actions(self):
+        return self._actions
+
+    def get_subcomponents(self):
+        return self._subcomponents
+
+    def get_primitive_type(self):
+        return self._primitive_type
+
+    def set_subcomponents(self, cc_classes, pc_classes):
+        self.all_possible_subcomponents[self.name] = self
+        list_of_defined_primitive_components = self.process_subcomponents(self, cc_classes, pc_classes)
+        for primitive_comp in list_of_defined_primitive_components:
+            self._subcomponents[primitive_comp.get_name()] = primitive_comp
+        self.construct_name_base_name_map()
+
+    def process_subcomponents(self, component, cc_classes, pc_classes):
+        """ generate a list of primitive subcomponents of a compound component"""
+
+        list_of_primitive_components = []
+        component_class = cc_classes[component.get_class_name()]
+        compound_attributes = component.get_attributes()
+        subcomponents = deepcopy(component_class.get_subcomponents_as_dict())
+        for default_sub_name, subcomponent in subcomponents.items():
+            defined_sub_name = CompoundComponent.define_subcomponent_name(default_sub_name, compound_attributes)
+            subcomponent.set_name(defined_sub_name)
+        # process the subcomponent attribute values, subcomponent attributes can be:
+        #     1. numbers
+        #     2. string bindings to/arithmetic operations of compound component attributes
+        # default sub-component-component attribute values that are not specified in the top-level, default values can be :
+        #     1. numbers
+        #     2. bindings/arithmetic operations of other sub-compound-component attribute values
+        for subname, subcomponent in subcomponents.items():
+            # create nested name for subcomponents
+            subname = component.get_name() + '.' + subcomponent.get_name() if component is not self \
+                                                                           else subcomponent.get_name()
+            subcomponent.set_name(subname)
+            subclass_name = subcomponent.get_class_name()
+            sub_class_type = 'compound' if subclass_name in cc_classes else 'primitive'
+            if sub_class_type == 'compound':
+                subclass_def = cc_classes[subclass_name]
+                defined_subcomponent = CompoundComponent.define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass_def)
+                list_of_new_defined_primitive_components = self.process_subcomponents(defined_subcomponent, cc_classes, pc_classes)
+                for new_defined_pc in list_of_new_defined_primitive_components:
+                    list_of_primitive_components.append(new_defined_pc)
             else:
-                ASSERT_MSG(input_parser_version == 0.2 or input_parser_version == 0.3,
-                           'input parser version for %s is v%s, cannot be parsed by current accelergy v%s'
-                           % (input_file_path, input_parser_version, self.parser_version))
+                subclass_def = pc_classes[subclass_name]
+                defined_subcomponent = CompoundComponent.define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass_def)
+                list_of_primitive_components.append(defined_subcomponent)
+            self.all_possible_subcomponents[subname] = defined_subcomponent
 
-            # if input_parser_version < self.parser_version:
-            #     WARN('Your %s input file has an older version. The most up-to-date version is %s '
-            #          '--> Only the value of the "version" key needs to be updated '
-            #          '(the syntax of the content does not need to be updated) '
-            #          '\n --- OK'
-            #          %(input_file_path, self.parser_version))
-        else:
-            ASSERT_MSG(input_parser_version == 0.3,
-                       'ERT input file is version v%s, cannot be parsed by Accelergy v%s. '
-                       '\n---> Please use Accelergy v0.2/ update your ERT input file format/ '
-                       'regenerate the ERT using your design description'
-                       % (input_parser_version, self.parser_version))
+        return list_of_primitive_components
 
-    def load_and_construct_dicts(self):
-        # load and classify input files
 
-        # construct new or parse existing config file
-        self.construct_parse_config_file()
-        
-        # merge all paths (input + compound compondnt lib)
-        all_paths = self.path_arglist
-        for cc_lib_path in self.config["compound_components"]:
-            all_paths.append(cc_lib_path)
-        
-        # go through each path in the merged list
-        input_file_info = {}
-        for path in all_paths:
-            if os.path.isfile(path) and path.split('.')[-1] == "yaml":
-                loaded_content_list = self.load_file(path)
-                for loaded_content in loaded_content_list:
-                    if loaded_content['top_key'] not in input_file_info:
-                        input_file_info[loaded_content['top_key']] = []
-                    input_file_info[loaded_content['top_key']].append(loaded_content)
-            elif os.path.isdir(path):
-                for root, directories, file_names in os.walk(path):
-                    for file_name in file_names:
-                        if file_name.split('.')[-1] == "yaml":
-                            file_path = os.path.join(root, file_name)
-                            loaded_content_list = self.load_file(file_path)
-                            for loaded_content in loaded_content_list:
-                                if loaded_content['top_key'] not in input_file_info:
-                                    input_file_info[loaded_content['top_key']] = []
-                                input_file_info[loaded_content['top_key']].append(loaded_content)
+    def flatten_action_list(self, cc_classes):
+        top_level_action_list = self.flatten_top_level_action_list(cc_classes[self.get_class_name()])
+        for action_idx in range(len(top_level_action_list)):
+            primitive_list = self.flatten_action_list_for_an_action(self.get_name(),
+                                                                    top_level_action_list[action_idx],
+                                                                    cc_classes)
+            top_level_action_list[action_idx].set_primitive_list(primitive_list)
+        self._actions = top_level_action_list
+
+
+    def flatten_action_list_for_an_action(self, component_name, action, cc_classes):
+        list_of_primitive_actions = []
+        # 1. expand the list of subcomponents in the action (subcomponent name can be in list format)
+        # 2. rename each subcomponent with hierarchical name
+        # 3. define the range of the arguments of each subcomponent action
+        # 4. if the action is a compound action -> go to 1
+        #    if the action is a primitive action -> throw it in the list
+        action_copy = deepcopy(action)
+        subcomponent_actions = action_copy.get_subcomps() # subcomponent_name: list of action objects
+        compound_attributes = self.find_subcomponent_obj(component_name).get_attributes()
+        compound_arguments = action.get_arguments()
+        aggregated_mappings = deepcopy(compound_attributes) if compound_arguments is None \
+                              else merge_dicts(compound_attributes, compound_arguments)
+
+        for subcomp_name, action_obj_list in subcomponent_actions.items():
+            # make sure the top-level component name is not added as prefix
+            if not component_name == self.get_name():
+                defined_subcomp_name = component_name + '.' + CompoundComponent.define_subcomponent_name(subcomp_name, aggregated_mappings)
             else:
-                ERROR_CLEAN_EXIT('Cannot recognize input path: ', path)
+                defined_subcomp_name = CompoundComponent.define_subcomponent_name(subcomp_name, aggregated_mappings)
 
-        if 'variables' in input_file_info:
-            for variable_spec in input_file_info['variables']:
-                for var_name, var_var in variable_spec['content']['variables'].items():
-                    if type(var_var) is str:
-                        if var_var in variable_spec['content']['variables']:
-                            variable_spec['content']['variables'][var_name] = variable_spec['content']['variables'][var_var]
-                        else:
-                            v = parse_expression_for_arithmetic(var_var, variable_spec['content']['variables'])
-                            if isinstance(v, str):
-                                arithmetic_failed_evaluate_warn(var_var, var_name, 'variables', variable_spec['content']['variables'])
-                            variable_spec['content']['variables'][var_name] = v
-
-                self.arch_variables.update(variable_spec['content']['variables'])
-
-        for top_key, top_key_file_list in input_file_info.items():
-            if top_key != 'variables':
-                for file_info in top_key_file_list:
-                    YAML_parser_fname = top_key + '_input_parser'
-                    file_path = file_info['path']
-                    INFO('Parsing file %s for %s info' % (file_path, top_key))
-                    getattr(self, YAML_parser_fname)(file_info)
-
-
-        # construct primitive classes dictionary
-        self.primitive_classes_input_parser()
-
-    def load_file(self, file_path):
-        if '.yaml' in file_path:
-            file_obj = open(file_path)
-            file = load(file_obj, accelergy_loader)
-            loaded_content_list =[]
-            for top_key in file.keys():
-                if top_key not in self.possible_top_keys:
-                    WARN('Cannot recognize the top key "%s" in file %s' % (top_key, file_path))
+            subclass_name = self.find_subcomponent_obj(defined_subcomp_name).get_class_name()
+            subcomponent_class_type = 'compound' if subclass_name in cc_classes else 'primitive'
+            defined_action_obj_list = CompoundComponent.define_subactions(action_obj_list, aggregated_mappings)
+            for subaction in defined_action_obj_list:
+                if subcomponent_class_type == 'primitive':
+                    list_of_primitive_actions.append((defined_subcomp_name, subaction))
                 else:
-                    # YAML_parser_fname = top_key + '_input_parser'
-                    loaded_content_list.append({'top_key': top_key, 'content': file, 'path': file_path})
-                    # getattr(self, YAML_parser_fname)(file_info)
-            file_obj.close()
-            return loaded_content_list
+                    default_subcomp_actions = deepcopy(cc_classes[subclass_name].get_action(subaction.get_name()).get_subcomps())
+                    subaction.set_subcomps(default_subcomp_actions)
+                    new_list_of_primitive_actions = self.flatten_action_list_for_an_action(defined_subcomp_name, subaction, cc_classes)
+                    for new_primitive_action in new_list_of_primitive_actions:
+                        list_of_primitive_actions.append(new_primitive_action)
+        return list_of_primitive_actions
 
-    def architecture_input_parser(self, file_info):
-        """responsible for parsing the loaded architecture YAML file """
-
-        top_key = 'architecture'
-        content = file_info['content']
-        file_path = file_info['path']
-
-        # only one arch file is allowed
-        ASSERT_MSG(self.hier_arch_spec_dict == {},
-                   'Second architecture description detected at %s ... '
-                   'Only one architecture is allowed...' % (file_path))
-
-        # check top-level syntax of input file
-        ASSERT_MSG('version' in content[top_key], '%s must contain "version" key' % (file_path))
-        self.check_input_parser_version(content[top_key]['version'], 'architecture', file_path)
-
-        if 'subtree' in content[top_key]:
-            ASSERT_MSG(type(content[top_key]['subtree']) is list,
-                       'File content not legal: %s, subtree key must have value of type list' % (file_path))
-        elif 'local' in content[top_key]:
-            ASSERT_MSG(type(content[top_key]['local']) is list,
-                       'File content not legal: %s, local key must have value of type list' % (file_path))
-        else:
-            ERROR_CLEAN_EXIT('Architecture Description must contain subtree or local key at top-level')
-
-        # create arch spec dict
-        self.hier_arch_spec_dict = {'architecture': {}}
-        self.flatten_arch_spec_dict = {'version': self.parser_version, 'components': {}}
-        arch_comp_list = content[top_key]
-        if 'subtree' in arch_comp_list:
-            arch_name = arch_comp_list['subtree'][0]['name']
-            global_attributes = {} if 'attributes' not in arch_comp_list['subtree'][0] \
-                else arch_comp_list['subtree'][0]['attributes']
-            if 'attributes' in arch_comp_list['subtree']:
-                ASSERT_MSG(type(arch_comp_list['subtree'['attributes']]) is dict,
-                           'attributes must be specified in dictionary format')
-            arch_comp_list['subtree'][0] = self.tree_node_classification(OrderedDict(arch_comp_list['subtree'][0]), arch_name, global_attributes)
-        else:
-            arch_comp_list = self.tree_node_classification(arch_comp_list, None, {})
-        self.hier_arch_spec_dict['architecture'] = OrderedDict(arch_comp_list)
-
-    def tree_node_classification(self, node_description, prefix, node_attrs):
-        """
-        Classify the nodes in a level to recursively parse (subtree) or construct components (local) for the architecture
-        :param node_description: a dictionary that describes the subtree and local nodes in this level
-        :param prefix: the prefix that needs to be preappend to all of the node names in this level
-        :param node_attrs: a dictionary that contains the explicitly specified attributes and the projected upper level shared attributes
-        :return: None
-        """
-        # interpret the mapping and arithmetic operations in the raw description
-        all_attrs = deepcopy(node_attrs)
-        all_attrs.update(self.arch_variables)
-        for attr_name, attr_val in node_attrs.items():
-            if type(attr_val) is str:
-                if attr_val in all_attrs:
-                    node_attrs[attr_name] = all_attrs[attr_val]
-                    all_attrs[attr_name] = all_attrs[attr_val]
-                else:
-                    v = parse_expression_for_arithmetic(attr_val, all_attrs)
-                    if isinstance(v, str):
-                        arithmetic_failed_evaluate_warn(attr_val, attr_name, prefix, node_attrs)
-                    node_attrs[attr_name] = v
-                    all_attrs[attr_name] = node_attrs[attr_name]
-
-        if 'subtree' in node_description:
-            ASSERT_MSG(isinstance(node_description['subtree'], list), " %s.subtree has to be a list"%(prefix))
-            node_description['subtree'] = self.parse_architecture_subtree(node_description['subtree'], prefix, node_attrs)
-
-        if 'local' in node_description:
-            ASSERT_MSG(isinstance(node_description['local'], list),
-                       "error: %s.local has to be a list of components"%prefix)
-            for c_id in range(len(node_description['local'])):
-                node_info = node_description['local'][c_id]
-                ASSERT_MSG('name' in node_info, 'name must be specified for each node')
-                if 'attributes' not in node_info:
-                    node_info['attributes'] = {}
-                else:
-                    ASSERT_MSG(type(node_info['attributes']) is dict,
-                    '%s: attributes must be specified in dictionary format'%(node_info['name']))
-                for attr_name, attr_val in node_attrs.items():
-                    if attr_name not in node_info['attributes']:
-                        node_info['attributes'][attr_name] = attr_val
-
-                all_attrs = deepcopy(node_info['attributes'])
-                all_attrs.update(self.arch_variables)
-                for attr_name, attr_val in node_info['attributes'].items():
-                    if type(attr_val) is str:
-                        if attr_val in all_attrs:
-                            node_info['attributes'][attr_name] = all_attrs[attr_val]
-                            all_attrs[attr_name] = all_attrs[attr_val]
-                        else:
-                            v = parse_expression_for_arithmetic(attr_val, all_attrs)
-                            if isinstance(v, str):
-                                arithmetic_failed_evaluate_warn(attr_val, attr_name, 'variables', node_info)
-                            node_info['attributes'][attr_name] = v
-                            all_attrs[attr_name] = node_info['attributes'][attr_name]
-
-
-                name_base, list_suffix, list_length = interpret_component_list(node_info['name'], all_attrs)
-                if list_suffix is not None:
-                    node_info['name'] = name_base + list_suffix
-
-                node_description['local'][c_id] = OrderedDict(node_info)
-
-                # generate the flattened version of the architecture
-                local_node_name = prefix + '.' + node_info['name'] if prefix is not None else node_info['name']
-                node_info['name'] = local_node_name
-                self.flatten_arch_spec_dict['components'][local_node_name] = node_info
-
-        if 'subtree' not in node_description and 'local' not in node_description:
-            ERROR_CLEAN_EXIT('Unrecognized tree node type', node_description)
-
-        return node_description
-
-    def parse_architecture_subtree(self, subtree_description, prefix, shared_attributes_dict=None):
-        ASSERT_MSG(isinstance(subtree_description, list), '%s.subtree needs to be a list'%prefix)
-
-        for subtree_idx in range(len(subtree_description)):
-            subtree_item_description = subtree_description[subtree_idx]
-            if 'name' not in subtree_item_description:
-                ERROR_CLEAN_EXIT('error: architecture description...',
-                                 ' "name" needs to be specified as a key in node description', subtree_item_description)
-
-            if shared_attributes_dict is None and 'attributes' not in subtree_item_description:
-                node_attrs = None
-            elif shared_attributes_dict is not None and 'attributes' not in subtree_item_description:
-                node_attrs = deepcopy(shared_attributes_dict)
-            elif shared_attributes_dict is None and 'attributes' in subtree_item_description:
-                node_attrs = subtree_item_description['attributes']
-            else:  # shared_attributes_dict is not None and attributes in node_description
-                node_attrs = deepcopy(shared_attributes_dict)
-                node_attrs.update(subtree_item_description['attributes'])
-
-            all_attrs = deepcopy(node_attrs)
-            all_attrs.update(self.arch_variables)
-            node_name = subtree_item_description['name']
-            name_base, list_suffix, list_length = interpret_component_list(node_name, all_attrs)
-            if list_suffix is not None:
-                node_name = name_base + list_suffix
-            subtree_item_description['name'] = node_name
-            item_prefix = prefix + '.' + node_name  # generated for the flattened arch
-            subtree_description[subtree_idx] = OrderedDict(self.tree_node_classification(subtree_item_description, item_prefix, node_attrs))
-        return subtree_description  # accumulated hierarchical info for the hierarchical arch
-
-    def compound_components_input_parser(self, file_info):
-        """responsible for parsing the loaded compound component description YAML files """
-
-        top_key = 'compound_components'
-
-        file_path = file_info['path']
-        file_reload = load(open(file_path), accelergy_loader_ordered)
-        content = file_reload
-
-        # check top level syntax, check parser version
-        ASSERT_MSG('version' and 'classes' in content[top_key],
-                   'File content not legal: %s, %s must contain '
-                   '"version" and "classes" keys' % (file_path, top_key))
-        self.check_input_parser_version(content[top_key]['version'], 'compound_component', file_path)
-        ASSERT_MSG(type(content[top_key]['classes']) is list,
-                   'File content not legal: %s, "classes" key must have value of type list' % file_path)
-
-        # check syntax of each specified cc class and add into the cc_class_dict
-        cc_classes_list = content[top_key]['classes']
-        for cc_class in cc_classes_list:
-            ASSERT_MSG('name' in cc_class.keys() and 'attributes' in cc_class.keys()
-                       and 'actions' in cc_class.keys() and 'subcomponents' in cc_class.keys(),
-                       'missing required keys in compound component class description: \n %s' % cc_class)
-            if cc_class['name'] in self.cc_classes_dict:
-                WARN('Redefined compound component class %s in file %s' % (cc_class['name'], file_path))
-            for subcomponent_info in cc_class['subcomponents']:
-                ASSERT_MSG('name' in subcomponent_info.keys() and 'class' in subcomponent_info.keys(),
-                           '"name" and "class" keys must be specified for the subcomponents of the '
-                           'compound component class: %s' % (cc_class['name']))
-                if 'area_share' not in subcomponent_info:
-                    subcomponent_info['area_share'] = 1  # default area share is 1
-            for action_info in cc_class['actions']:
-                ASSERT_MSG('name' in action_info.keys() and 'subcomponents' in action_info.keys(),
-                           '"name" and "subcomponents" keys must be specified for compound action %s' % (
-                           action_info['name']))
-                for subcomponent_actions in action_info['subcomponents']:
-                    ASSERT_MSG('actions' in subcomponent_actions and 'name' in subcomponent_actions,
-                               '"name" and "actions" keys of the subcomponent must be specified for compound action'
-                               ' %s' % (action_info['name']))
-                    for subcomponent_action in subcomponent_actions['actions']:
-                        ASSERT_MSG('name' in subcomponent_action,
-                                   '"name" key of the subcomponent action needs to be specified for '
-                                   'compound action: %s, subcomponent: %s' % (
-                                   action_info['name'], subcomponent_actions['name']))
-                        if 'action_share' not in subcomponent_action:
-                            if 'repeat' in subcomponent_action:
-                                subcomponent_action['action_share'] = subcomponent_action['repeat']
+    @staticmethod
+    def define_subactions(subactions, aggregated_dict):
+        defined_subactions = []
+        for subaction in subactions:
+            parsed_action_share = CompoundComponent.parse_action_share(subaction, aggregated_dict)
+            subaction.set_action_share(parsed_action_share)
+            if subaction.get_arguments() is not None:
+                for subarg_name, subarg_val in subaction.get_arguments().items():
+                    if type(subarg_val) is str:
+                        try:
+                            subaction.set_argument({subarg_name: aggregated_dict[subarg_val]})
+                        except KeyError:
+                            v = parse_expression_for_arithmetic(subarg_val, aggregated_dict)
+                            if not isinstance(v, str):
+                                subaction.set_argument({subarg_name: v})
                             else:
-                                subcomponent_action['action_share'] = 1  # default action share is 1
-            self.cc_classes_dict[cc_class['name']] = deepcopy(cc_class)
+                                print('available compound arguments and attributes: ', aggregated_dict)
+                                print('primitive argument to for binding:', subarg_val)
+                                ERROR_CLEAN_EXIT('subcomponent argument name cannot be ',
+                                                 'mapped to upper class arguments', subarg_val)
+            defined_subactions.append(subaction)
+        return defined_subactions
 
-    def construct_parse_config_file(self):
-        """load exisiting config file content (if any)/ create a default config file"""
+    @staticmethod
+    def parse_action_share(action, upper_level_binding):
+        """
+        evaluates the values of action_share of a sub-component action
+        - default value of action_share is 1
+        - string bindings are allowed, and bindings can be from:
+            1. compound attributes
+            2. compound action arguments (its own upper-level action)
+        - arithemtic operations are allowed in specifying action_share value
 
-        possible_config_dirs = ['.' + os.sep, os.path.expanduser('~') + '/.config/accelergy/']
-        config_file_name = 'accelergy_config.yaml'
-        for possible_dir in possible_config_dirs:
-            if os.path.exists(possible_dir + config_file_name):
-                original_config_file_path = possible_dir + config_file_name
-                original_content_obj = open(original_config_file_path)
-                original_content = load(original_content_obj, accelergy_loader)
-                original_content_obj.close()
-                INFO('config file located:', original_config_file_path)
-                print('config file content: \n', original_content)
-                if 'version' not in original_content:
-                    ERROR_CLEAN_EXIT('config file has no version number, cannot proceed')
-                file_version = original_content['version']
-                self.check_input_parser_version(file_version, 'config', original_config_file_path)
-                self.config = original_content
-                return
-
-        create_folder(possible_config_dirs[1])
-        config_file_path = possible_config_dirs[1] + config_file_name
-        curr_file_path = os.path.abspath(__file__)
-        accelergy_share_folder_path = os.path.abspath(curr_file_path + '../../../../../../share/accelergy/')
-        default_estimator_path = os.path.abspath(accelergy_share_folder_path + '/estimation_plug_ins/')
-        default_pc_lib_path = os.path.abspath(accelergy_share_folder_path + '/primitive_component_libs/')
-        
-        config_file_content = {'version': self.parser_version,
-                               'estimator_plug_ins': [default_estimator_path],
-                               'primitive_components': [default_pc_lib_path],
-                               'compound_components': []}  # by default, CCs are always input files
-
-        INFO('Accelergy creating default config at:', possible_config_dirs[1] + config_file_name, 'with:\n',
-             config_file_content)
-        write_yaml_file(config_file_path, config_file_content)
-        self.config = config_file_content
-
-    def primitive_classes_input_parser(self):
-        """construct a dictionary for primitive classes"""
-        primitive_class_paths = self.config['primitive_components']
-        for pc_path in primitive_class_paths:
-            if '.yaml' in pc_path:
-                self.expand_primitive_component_lib_info(pc_path)
-            for root, directories, file_names in os.walk(pc_path):
-                for file_name in file_names:
-                    if '.lib.yaml' in file_name:
-                        pc_path = root + os.sep + file_name
-                        self.expand_primitive_component_lib_info(pc_path)
-
-        ASSERT_MSG(not len(self.pc_classes_dict) == 0, 'No primitive component class found, '
-                                                       'please check if the paths in config file are correct')
-
-
-    def expand_primitive_component_lib_info(self, pc_path):
-        primitive_component_list_obj = open(pc_path)
-        primitive_component_list = load(primitive_component_list_obj, accelergy_loader)
-        primitive_component_list_obj.close()
-        for idx in range(len(primitive_component_list['classes'])):
-            pc_description = primitive_component_list['classes'][idx]
-            if pc_description['name'] in self.pc_classes_dict:
-                WARN(pc_description['name'], 'redefined in', pc_path)
-            self.pc_classes_dict[pc_description['name']] = deepcopy(pc_description)
-        INFO('primitive component file parsed: ', pc_path)
-
-    def ERT_input_parser(self, file_info):
-        top_key = 'ERT'
-        file_path = file_info['path']
-        content = file_info['content'][top_key]
-        ERT_component_entry_list = content['tables']
-
-        ASSERT_MSG('version' and 'tables' in content, 'ERT input must contain the "version" and "tables" keys')
-        ASSERT_MSG(isinstance(content['tables'], list), 'ERT tables must be in the form of list')
-        self.check_input_parser_version(content['version'], 'ERT', file_path)
-
-        for ERT_component_entry in ERT_component_entry_list:
-            ASSERT_MSG('name' and 'actions' in ERT_component_entry,
-                       '"name" and "actions" keys must be specified in each ERT component entry')
-            component_name = ERT_component_entry['name']
-            action_dict_summary = {}
-            action_list = ERT_component_entry['actions']
-            for action in action_list:
-                if action['name'] not in action_dict_summary: action_dict_summary[action['name']] = []
-                action_dict_summary[action['name']].append(action)
-            self.ERT_dict[component_name] = action_dict_summary
-
-    def action_counts_input_parser(self, file_info):
-        top_key = 'action_counts'
-        file_path = file_info['path']
-        ASSERT_MSG('version' in file_info['content'][top_key],
-                   'Please specify the version of the action counts file: %s' % (file_path))
-        self.check_input_parser_version(file_info['content'][top_key]['version'], 'action counts', file_path)
-        action_counts_dict = file_info['content'][top_key]
-        ASSERT_MSG('subtree' in action_counts_dict or 'local' in action_counts_dict,
-                   'the action counts must contain the "subtree" key or "local" key at the top level: %s' % file_path)
-        self.flatten_action_counts(None, action_counts_dict)
-
-    def flatten_action_counts(self, prefix, node_description):
-        if 'local' in node_description:
-            local_nodes = node_description['local']
-            ASSERT_MSG(isinstance(local_nodes, list), 'local nodes are not specified in list format in action counts')
-            for local_node in local_nodes:
-                ASSERT_MSG("name" and 'action_counts' in local_node, '"name" and "action_counts" need to be '
-                                                                     'specified as a keys in action count local node descriptions: %s' % local_node)
-                if prefix is None:
-                    full_name = local_node['name']
+        """
+        action_share = action.get_action_share()
+        if action_share is not None:
+            if type(action_share) is not int:
+                v = parse_expression_for_arithmetic(action_share, upper_level_binding)
+                if not isinstance(v, str):
+                    parsed_action_share = v
                 else:
-                    full_name = prefix + '.' + local_node['name']
-                self.action_counts_dict[full_name] = local_node['action_counts']
+                    if action_share in upper_level_binding:
+                       parsed_action_share = upper_level_binding[action_share]
+                    else:
+                        parsed_action_share = None
+                        ERROR_CLEAN_EXIT('action_share/repeat value for primitive action cannot be parsed, ',
+                                      'no binding found in compound arguments/ attributes',action,
+                                         'available binding:', upper_level_binding)
+                return parsed_action_share
+            # return the actual value if action_share is an integer
+            return action_share
+        # default action_share value is 1
+        return 1
 
-        if 'subtree' in node_description:
-            subtree_nodes = node_description['subtree']
-            ASSERT_MSG(isinstance(subtree_nodes, list),
-                       'subtree nodes are not specified in list format in action counts')
-            for subtree_node_description in subtree_nodes:
-                ASSERT_MSG("name" in subtree_node_description, ' "name" need to be specified in the subtree node: %s'
-                           % subtree_node_description)
-                if prefix is None:
-                    subtree_prefix = subtree_node_description['name']
+    def flatten_top_level_action_list(self, component_class):
+        actionNameList = component_class.get_action_name_list()
+        flattenedActionList = []
+        for actionName in actionNameList:
+            actionObj = deepcopy(component_class.get_action(actionName))
+            flattened = actionObj.flatten_action_args_into_list(self.attributes)
+            for action in flattened:
+                flattenedActionList.append(action)
+        return flattenedActionList
+
+    @staticmethod
+    def define_subcomponent_name(subcomponent_name, mapping_dictionary):
+        # define the list index specified in the subcomponents (if any)
+        # mapping dictionary contains key-value paris where the keys can be used as reference in the list definition
+
+        name_base, list_suffix, list_length = interpret_component_list(subcomponent_name, mapping_dictionary)
+        if list_suffix is not None: subcomponent_name = name_base + list_suffix
+        return subcomponent_name
+
+
+    @staticmethod
+    def define_attrs_area_share_for_subcomponent(subcomponent, compound_attributes, subclass):
+        for attr_name, attr_val in subcomponent.get_attributes().items():
+            if type(attr_val) is str:
+                if attr_val in compound_attributes:
+                    subcomponent.add_new_attr({attr_name: compound_attributes[attr_val]})
                 else:
-                    subtree_prefix = prefix + '.' + subtree_node_description['name']
-                self.flatten_action_counts(subtree_prefix, subtree_node_description)
+                    v = parse_expression_for_arithmetic(attr_val, compound_attributes)
+                    subcomponent.add_new_attr({attr_name: v})
+                    if isinstance(v, str):
+                        arithmetic_failed_evaluate_warn(attr_val, attr_name, subcomponent.get_name(), compound_attributes)
+                        
+        attrs_to_be_applied = subclass.get_default_attr_to_apply(subcomponent.get_attributes())
+        subcomponent.add_new_attr(attrs_to_be_applied)
+        CompoundComponent.apply_internal_bindings(subcomponent)
+        if type(subcomponent.get_area_share()) is str:
+            combined_attributes = merge_dicts(compound_attributes, subcomponent.get_attributes())
+            v = parse_expression_for_arithmetic(subcomponent.get_area_share(), combined_attributes)
+            if not isinstance(v, str):
+                subcomponent.set_area_share(v)
+            else:
+                ASSERT_MSG(subcomponent.get_area_share() in combined_attributes,
+                           'Unable to interpret the area share for subcomponent: %s' %(subcomponent.get_name()))
+                subcomponent.set_area_share(combined_attributes[subcomponent.get_area_share()])
+        return subcomponent
 
-    def get_hier_arch_spec_dict(self):
-        ASSERT_MSG(not self.hier_arch_spec_dict == {}, 'Cannot get hierarchical architecture spec from raw inputs')
-        return self.hier_arch_spec_dict
+    @staticmethod
+    def apply_internal_bindings(component):
+        """ Locate and process any mappings or arithmetic operations between the component attributes"""
 
-    def get_flatten_arch_spec_dict(self):
-        ASSERT_MSG(not self.flatten_arch_spec_dict == {}, 'Cannot get architecture spec from raw inputs')
-        return self.flatten_arch_spec_dict
+        for attr_name, attr_val in component.get_attributes().items():
+            if type(attr_val) is str:
+                if attr_val in component.get_attributes():
+                    component.add_new_attr({attr_name: component.get_attributes()[attr_val]})
+                else:
+                    v = parse_expression_for_arithmetic(attr_val, component.get_attributes())
+                    component.add_new_attr({attr_name:v})
+                    if isinstance(v, str):
+                        arithmetic_failed_evaluate_warn(attr_val, attr_name, component.get_name(), component.get_attributes())
 
-    def get_pc_classses(self):
-        ASSERT_MSG(not self.pc_classes_dict == {}, 'Cannot get primitive component class from raw inputs')
-        return self.pc_classes_dict
+    def construct_name_base_name_map(self):
+        self.subcomponent_base_name_map = {}
+        for subname in self.all_possible_subcomponents:
+            sub_base_name = remove_brackets(subname)
+            self.subcomponent_base_name_map[sub_base_name] = subname
 
-    def get_cc_classses(self):
-        if self.cc_classes_dict == {}:
-            WARN('No compound component classes specified, architecture can only contain primitive components')
-        return self.cc_classes_dict
+    def find_subcomponent_obj(self, subcomponent_name):
+        """ find the corresponding subcomponent def to retrieve the action-related information"""
 
-    def get_estimation_plug_in_paths(self):
-        ASSERT_MSG(self.config is not None and 'estimator_plug_ins' in self.config,
-                   'config is not properly defined \n %s' % self.config)
-        path_list = self.config['estimator_plug_ins']
-        return path_list
+        subcomponent_base_name = remove_brackets(subcomponent_name)
+        ASSERT_MSG(self.subcomponent_base_name_map[subcomponent_base_name] in self.all_possible_subcomponents,
+                   'subcomponent: %s not found'%(self.subcomponent_base_name_map[subcomponent_base_name]))
+        subcomp_obj = self.all_possible_subcomponents[self.subcomponent_base_name_map[subcomponent_base_name]]
+        ASSERT_MSG(comp_name_within_range(subcomponent_name, subcomp_obj.get_name()),
+                   'subcompnent name %s in action definition does not have a valid index (should be a subset of %s)'
+                   %(subcomponent_name, subcomp_obj.get_name()))
+        return subcomp_obj
 
-    def get_action_counts_dict(self):
-        if self.action_counts_dict == {}:
-            WARN('No action counts are specified as yaml input')
-        return self.action_counts_dict
 
-    def get_ERT_dict(self):
-        if self.ERT_dict == {}:
-            WARN('No ERT is specified as yaml input')
-        return self.ERT_dict
 
-    def get_available_inputs(self):
-        available_inputs = []
-        if not self.flatten_arch_spec_dict == {}:
-            available_inputs.append('architecture_spec')
-        if not self.cc_classes_dict == {}:
-            available_inputs.append('compound_component_classes')
-        if not self.action_counts_dict == {}:
-            available_inputs.append('action_counts')
-        if not self.ERT_dict == {}:
-            available_inputs.append('ERT')
-        return available_inputs
+    # ------------ CONVERSION TO DICTS for BETTER OUTPUTS FUNCTIONS ------------#
+    def get_subcomponents_as_dict(self):
+        subcomp_dict = {}
+        for sub_name, sub_obj in self._subcomponents.items():
+            subcomp_dict[sub_name] = {'class': sub_obj.get_class_name(),
+                                      'attributes': sub_obj.get_attributes(),
+                                      'area_share': sub_obj.get_area_share()}
+        return subcomp_dict
+
+    def get_dict_representation(self):
+        """ Generate the information of the component component in a dictionary format
+            including: (1) attributes (2) class (2) flattened primitive list (2) flattened actions
+        """
+
+        from collections import OrderedDict
+        cc_dict = OrderedDict()
+
+        subcomponent_dict = self.get_subcomponents_as_dict()
+        subcomponent_list = []
+        for subcomp_name, subcomp_info_dict in subcomponent_dict.items():
+            new_info_dict = OrderedDict({'name': subcomp_name})
+            new_info_dict.update(subcomp_info_dict)
+            subcomponent_list.append(new_info_dict)
+
+        cc_dict.update({'name': self.get_name(),
+                        'class': self.get_class_name(),
+                        'attributes': self.get_attributes(),
+                        'primitive_components': subcomponent_list,
+                        'actions': []})
+        idx = 0
+        for action in self._actions:
+            cc_dict['actions'].append(OrderedDict({'name': action.get_name(),
+                                                   'arguments': action.get_arguments(),
+                                                   'primitive_actions': []}))
+            for pc_action_tuple in action.get_primitive_list():
+                cc_dict['actions'][idx]['primitive_actions'].append(
+                    OrderedDict({'name': pc_action_tuple[0],
+                                 'action': pc_action_tuple[1].get_name(),
+                                 'arguments': pc_action_tuple[1].get_arguments(),
+                                 'action_share': pc_action_tuple[1].get_action_share()}))
+            idx = idx + 1
+        return cc_dict

--- a/accelergy/parsing_utils.py
+++ b/accelergy/parsing_utils.py
@@ -40,6 +40,7 @@ MATH_FUNCS = {
     'range': range, 'len': len, 'min': min, 'max': max
 }
 EXPR_CACHE = {}
+WARNINGS_LOGGED = []
 
 def interpret_component_list(name, binding_dictionary = None):
     """
@@ -80,6 +81,16 @@ def str_to_int(str_to_be_parsed, binding_dictionary):
             parsed_int = binding_dictionary[str_to_be_parsed] if str_to_be_parsed in binding_dictionary \
                                                           else int(str_to_be_parsed)
     return parsed_int
+
+def arithmetic_failed_evaluate_warn(expr, setting, name, binding_dictionary, error=False):
+    if (expr, setting) in WARNINGS_LOGGED:
+        return
+
+    warnstring = f'Failed to evaluate "{expr}". Setting {name}.{setting}="{expr}". Available bindings: {binding_dictionary}'
+    warnstring = 'WARN: ' + warnstring if not error else 'ERROR: ' + warnstring
+
+    print(warnstring)
+    WARNINGS_LOGGED.append((expr, setting))
 
 def parse_expression_for_arithmetic(expression, binding_dictionary, force_convert_numeric_on_fail=False):
     """

--- a/accelergy/raw_inputs_2_dicts.py
+++ b/accelergy/raw_inputs_2_dicts.py
@@ -89,10 +89,9 @@ class RawInputs2Dicts():
                             variable_spec['content']['variables'][var_name] = variable_spec['content']['variables'][var_var]
                         else:
                             v = parse_expression_for_arithmetic(var_var, variable_spec['content']['variables'])
-                            if not isinstance(v, str):
-                                variable_spec['content']['variables'][var_name] = v
-                            else:
-                                print(f'ERROR: {var_var} is not a valid expression. Not setting "variables" attribute in {variable_spec}')
+                            if isinstance(v, str):
+                                arithmetic_failed_evaluate_warn(var_var, var_name, 'variables', variable_spec['content']['variables'])
+                            variable_spec['content']['variables'][var_name] = v
 
                 self.arch_variables.update(variable_spec['content']['variables'])
 
@@ -182,11 +181,10 @@ class RawInputs2Dicts():
                     all_attrs[attr_name] = all_attrs[attr_val]
                 else:
                     v = parse_expression_for_arithmetic(attr_val, all_attrs)
-                    if not isinstance(v, str):
-                        node_attrs[attr_name] = vars
-                        all_attrs[attr_name] = node_attrs[attr_name]
-                    else:
-                        print(f'ERROR: {attr_val} is not a valid expression. Not setting "{attr_name}" attribute in {node_attrs}')
+                    if isinstance(v, str):
+                        arithmetic_failed_evaluate_warn(attr_val, attr_name, prefix, node_attrs)
+                    node_attrs[attr_name] = v
+                    all_attrs[attr_name] = node_attrs[attr_name]
 
         if 'subtree' in node_description:
             ASSERT_MSG(isinstance(node_description['subtree'], list), " %s.subtree has to be a list"%(prefix))
@@ -216,11 +214,12 @@ class RawInputs2Dicts():
                             all_attrs[attr_name] = all_attrs[attr_val]
                         else:
                             v = parse_expression_for_arithmetic(attr_val, all_attrs)
-                            if not isinstance(v, str):
-                                node_info['attributes'][attr_name] = v
-                                all_attrs[attr_name] = node_info['attributes'][attr_name]
-                            else:
-                                print(f'ERROR: {attr_val} is not a valid expression. Not setting "{attr_name}" attribute in {node_info}')
+                            if isinstance(v, str):
+                                arithmetic_failed_evaluate_warn(attr_val, attr_name, 'variables', node_info)
+                            node_info['attributes'][attr_name] = v
+                            all_attrs[attr_name] = node_info['attributes'][attr_name]
+
+
                 name_base, list_suffix, list_length = interpret_component_list(node_info['name'], all_attrs)
                 if list_suffix is not None:
                     node_info['name'] = name_base + list_suffix


### PR DESCRIPTION
My last pull request introduced the following problems:
   - Invalid arithmetic expressions are reported multiple times when propagated different places
   - Invalid arithmetic expressions are not populated in node attributes

The latter caused problems because string expressions like "32nm" and "1ns" are invalid arithmetic expressions and would be skipped.

Both are skipped now: 
  - On invalid expression, a WARN is printed and the string value is propogated
  - WARN is only printed  once per invalid expression